### PR TITLE
Capitolo4: 4, 4.1, 4.2, 4.3

### DIFF
--- a/functions.md
+++ b/functions.md
@@ -8,9 +8,9 @@ fn main() {
 ```
 
 Questo è la dichiarazione di funzione più semplice possibile.
-Come accennato prima, c'è `fn` che dice ‘questa è una funzione’, ed è seguita
+Come accennato prima, `fn` indica che ‘questa è una funzione’, ed è seguita
 dal nome della funzione, da due parentesi vuote perché questa funzione
-non prende argomenti, e poi da graffe che contengono il corpo della funzione.
+non prende argomenti, e poi da parentesi graffe che contengono il corpo della funzione.
 Ecco una funzione chiamata `foo`:
 
 ```rust
@@ -39,10 +39,10 @@ fn stampa_numero(x: i32) {
 ```
 
 Come si vede, gli argomenti delle funzioni funzionano in modo molto simile
-alle dichiarazoni `let`:
-si aggiunge un tipo al nome dell'argomento, dopo un carattere `:`.
+alle dichiarazioni `let`:
+si aggiunge un tipo al nome dell'argomento, dopo i due punti `:`.
 
-Ecco un programma completo che addiziona due numeri e stampa il risultato:
+Ecco un programma completo che somma due numeri e stampa il risultato:
 
 ```rust
 fn main() {
@@ -73,7 +73,7 @@ expected one of `!`, `:`, or `@`, found `)`
 fn print_sum(x, y) {
 ```
 
-Questa è una precisa decisione progettuale. Per quanto sia possibile
+Questa è una ponderata decisione progettuale. Per quanto sia possibile
 l'inferenza di tipo sull'intero programma, i linguaggi che ce l'hanno,
 come Haskell, spesso suggeriscono che sia meglio documentare esplicitamente
 i propri tipi. Concordiamo che costringere le funzioni a dichiarare i tipi
@@ -107,7 +107,7 @@ fn somma_uno(x: i32) -> i32 {
      x + 1;
 }
 
-help: consider removing this punto-e-virgola:
+help: consider removing this semicolon:
      x + 1;
           ^
 ```
@@ -136,7 +136,7 @@ come espressioni, non come istruzioni. Come in Ruby:
 x = y = 5
 ```
 
-In Rust, però, l'uso di `let` per introdurre un legamo _non_ è un'espressione.
+In Rust, però, l'uso di `let` per introdurre un legame _non_ è un'espressione.
 La seguente riga produrrà un errore di compilazione:
 
 ```rust,ignore
@@ -151,7 +151,7 @@ Si noti che assegnare a una variabile già legata (per es. `y = 5`) è ancora
 un'espressione, per quanto il suo valore non sia particolarmente utile.
 Diversamente da altri linguaggi, nei quali un assegnamento ha come valore
 il valore assegnato (nell'esempio precedente, `5`), in Rust il valore
-di un assegnmento è un'ennupla vuota `()`, perché il valore assegnato può avere
+di un assegnamento è una ennupla vuota `()`, perché il valore assegnato può avere
 [solamente un possessore](ownership.html), e ogni altro valore reso sarebbe
 troppo sorprendente:
 
@@ -164,8 +164,8 @@ let x = (y = 6);  // x ha valore `()`, non `6`
 Il secondo genere di istruzioni in Rust è l'*istruzione espressione*. Il suo
 scopo è trasformare qualunque espressione in un'istruzione. In pratica,
 la grammatica di Rust si aspetta che delle istruzioni seguano altre istruzioni.
-Ciò significa che si usano punti-e-virgola per separare un'espressione
-dall'altra. Ciò significa che Rust è molto simile alla maggior parte degli
+Ciò significa che si usano punti-e-virgola per separare diverse espressioni.
+Ciò significa che Rust è molto simile alla maggior parte degli
 altri linguaggi che richiedono di usare punti-e-virgola alla fine di ogni riga,
 e si vedranno punti-e-virgola alla fine di quasi tutte le righe di codice Rust.
 
@@ -212,33 +212,33 @@ diventa intuitivo.
 ## Funzioni divergenti
 
 Rust ha alcune sintassi speciali per le ‘funzioni divergenti’, che sono
-le funzioni da cui non si esce più:
+le funzioni che non rendono nessun valore:
 
 ```rust
 fn diverge() -> ! {
-    panic!("Da questa funzione non si esce mai!");
+    panic!("Questa funzione non rende nessun valore!");
 }
 ```
 
 `panic!` è una macro, come lo è `println!()` che abbiamo già visto.
 Diversamente da `println!()`, `panic!()` manda in crash il thread corrente,
 stampando il messaggio ricevuto come argomento. Dato che questa funzione
-provocherà un crash, non si uscirà mai da essa, e quindi ha il tipo ‘`!`’,
+provocherà un crash, non renderà nessun valore, e quindi ha il tipo ‘`!`’,
 che si legge ‘diverge’.
 
 Se si aggiunge una funzione main che chiama `diverge()` e la si esegue,
 si otterrà un output simile a questo:
 
 ```text
-thread ‘main’ panicked at ‘Da questa funzione non si esce mai!’, main.rs:2
+thread ‘main’ panicked at ‘Questa funzione non rende nessun valore!’, main.rs:2
 ```
 
 Se si vogliono più informazioni, si può ottenere un backtrace impostando
 la variabile d'ambiente `RUST_BACKTRACE`:
 
 ```text
-$ RUST_BACKTRACE=1 ./diverge
-thread 'main' panicked at 'Da questa funzione non si esce mai!', main.rs:2
+$ rust_backtrace=1 ./diverge
+thread 'main' panicked at 'Questa funzione non rende nessun valore!', main.rs:2
 stack backtrace:
    1:     0x7f402773a829 - sys::backtrace::write::h0942de78b6c02817K8r
    2:     0x7f402773d7fc - panicking::on_panic::h3f23f9d0b5f4c91bu9w
@@ -255,16 +255,16 @@ stack backtrace:
   13:                0x0 - <unknown>
 ```
 
-Se serve scavalcare una variabile `RUST_BACKTRACE` già impostata, nel caso
+Se serve sovrascrivere una variabile `RUST_BACKTRACE` già impostata, nel caso
 in cui non si può semplicemente disimpostare la variabile, allora la si può
 impostare a `0` per evitare di ottenere un backtrace. Qualunque altro valore
-(anche nessun valore affatto) attiva il backtrace.
+(anche nessun valore) attiva le informazioni di backtrace.
 
 ```text
 $ export RUST_BACKTRACE=1
 ...
-$ RUST_BACKTRACE=0 ./diverge 
-thread 'main' panicked at 'Da questa funzione non si esce mai!', main.rs:2
+$ RUST_BACKTRACE=0 ./diverge
+thread 'main' panicked at 'Questa funzione non rende nessun valore!', main.rs:2
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 ```
 
@@ -273,7 +273,7 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 ```text
 $ RUST_BACKTRACE=1 cargo run
      Running `target/debug/diverge`
-thread 'main' panicked at 'Da questa funzione non si esce mai!', main.rs:2
+thread 'main' panicked at 'Questa funzione non rende nessun valore!', main.rs:2
 stack backtrace:
    1:     0x7f402773a829 - sys::backtrace::write::h0942de78b6c02817K8r
    2:     0x7f402773d7fc - panicking::on_panic::h3f23f9d0b5f4c91bu9w
@@ -295,7 +295,7 @@ di qualunque tipo:
 
 ```rust,should_panic
 # fn diverge() -> ! {
-#    panic!("Da questa funzione non si esce mai!");
+#    panic!("Questa funzione non rende nessun valore!");
 # }
 let x: i32 = diverge();
 let x: String = diverge();

--- a/primitive-types.md
+++ b/primitive-types.md
@@ -2,8 +2,8 @@
 
 Il linguaggio Rust ha vari tipi che sono considerati ‘primitivi’. Ciò
 significa che fanno parte del linguaggio. Rust è strutturato in modo tale
-che la libreria standard fornisce anche vari altri tipi utili, costruiti
-basandosi su quelli primitivi, ma che non sono considerati primitivi.
+che la libreria standard fornisca anche vari altri tipi utili, costruiti
+basandosi su quelli primitivi, ma quelli che vedremo sono i più primitivi.
 
 # Booleani
 
@@ -16,10 +16,9 @@ let x = true;
 let y: bool = false;
 ```
 
-I booleani sono usati tipicamente nei costrutti [`if`][if] e [`while`][while].
+I booleani sono usati tipicamente nei costrutti [`if`][if].
 
 [if]: if.html
-[while]: while.html
 
 Nella [documentazione della libreria standard][bool] si trova ulteriore
 documentazione sui `bool`.
@@ -29,15 +28,15 @@ documentazione sui `bool`.
 # `char`
 
 Il tipo `char` rappresenta un singolo valore scalare Unicode. Si possono
-creare dei `char` racchudendolo tra apici singoli: (`'`)
+creare dei `char` racchiudendoli tra apici singoli: (`'`)
 
 ```rust
 let x = 'x';
 let two_hearts = '💕';
 ```
 
-Diversamente da alcuni altri linguaggi, cioò significa che il `char` di Rust
-non è rappresentato a un singolo byte, ma da quattro byte.
+Diversamente da alcuni altri linguaggi, ciò significa che il `char` di Rust
+non è rappresentato con un singolo byte, ma da quattro byte.
 
 Nella [documentazione della libreria standard][char] si trova ulteriore
 documentazione sui `char`.
@@ -46,10 +45,10 @@ documentazione sui `char`.
 
 # Tipi numerici
 
-Rust ha parecchi tipi numerici, appartenenti alle seguenti categories:
+Rust ha parecchi tipi numerici, appartenenti alle seguenti categorie:
 con segno e senza segno, fissi e variabili, a virgola mobile e interi.
 
-Questi tipi consistono in due parti: la categoria, e la dimensione.
+Questi tipi consistono di due parti: la categoria, e la dimensione.
 Per esempio, `u16` è un tipo senza segno con una dimensione di sedici bit.
 Più bit consentono di rappresentare numeri più grandi.
 
@@ -62,7 +61,7 @@ let x = 42; // x ha tipo i32
 let y = 1.0; // y ha tipo f64
 ```
 
-Ecco una lista dei diversi tipi numerici, con link alla loro documentazione
+Ecco una lista dei diversi tipi numerici, con dei link alla loro documentazione
 nella libreria standard:
 
 * [i8](../std/primitive.i8.html)
@@ -83,7 +82,7 @@ Esaminiamoli in base alla loro categoria:
 ## Con segno e senza segno
 
 Ci sono due categorie di tipi interi: con segno e senza segno. Per comprendere
-la differenza, consideriamo un numero di 4 bit. Un numero di quattro bit,
+la differenza, consideriamo un numero di quattro bit. Un numero di quattro bit,
 con segno, consentirebbe di rappresentare i numeri da `-8` a `+7`. I numeri
 con segno usano la "rappresentazione in complemento a due". Un numero
 di quattro bit, senza segno, dato che non ha bisogno di rappresentare
@@ -92,21 +91,22 @@ valori negativi, può rappresentare valori da `0` a `+15`.
 I tipi con segno usano una `u` per la loro categoria, e i tipi con segno
 usano una `i`. La `u` sta per ‘unsigned’ ("senza segno"), mentre la `i`
 sta per ‘integer’ ("intero"). Perciò `u8` è un numero senza segno, a otto bit,
- e `i8` è un numbero con segno, pure a otto bit.
+ e `i8` è un numero con segno, sempre a otto bit.
 
 ## Tipi a dimensione fissa
 
 I tipi dimensione fissa hanno uno specifico numero di bit nella loro
-rappresentazione. Le dimensioni (in bit) valide sono `8`, `16`, `32`, e `64`.
+rappresentazione. Le dimensioni in bit valide sono `8`, `16`, `32`, e `64`.
 Perciò, `u32` è un intero senza segno, a 32 bit,
-mentre `i64` is a intero con segno, a 64 bit.
+e `i64` è un intero con segno, a 64 bit.
 
 ## Tipi a dimensione variabile
 
 Rust fornisce anche dei tipi la cui effettiva dimensione dipende
-dall'architettura di macchina target. L'ampiezza di questi tipi è sufficiente
-a esprimere la dimensione di qualunque collezione, perciò questi tipi
-appartengono alla categoria ‘size’ ("dimensione"). Anche loro hanno
+dall'architettura della macchina in questione.
+L'ampiezza di questi tipi è sufficiente
+ad esprimere la dimensione di qualunque collezione, perciò questi tipi
+appartengono alla categoria ‘size’ ('dimensione'). Anche loro hanno
 la versione con segno e quella senza segno, e quindi sono due:
 `isize` e `usize`.
 
@@ -114,12 +114,12 @@ la versione con segno e quella senza segno, e quindi sono due:
 
 Rust ha anche due tipi a virgola mobile: `f32` e `f64`. Questi corrispondono
 rispettivamente ai numeri a precisione singola e a precisione doppia
-secondo lo stardard IEEE-754.
+secondo lo standard IEEE-754.
 
-# Array
+# Arrays
 
 Come molti linguaggi di programmazione, Rust ha dei tipi compositi
-per rappresentare sequenze di oggetti. Il più basilare è il tipo *array*
+per rappresentare sequenze di dati. Il più basilare è il tipo *array*
 ("schiera"), una lista a lunghezza fissa di elementi dello stesso tipo.
 Di default, gli array sono immutabili.
 
@@ -160,8 +160,8 @@ println!("Il secondo nome è: {}", nomi[1]);
 Gli indici partono da zero, come nella maggior parte dei linguaggi
 di programmazione, e perciò il primo nome è `nomi[0]` e il secondo nome è
 `nomi[1]`. L'esempio precedente stampa `Il secondo nome è: Brian`.
-Provando a usare un indice non compreso nell'array, si ottiene un errore,
-perché per ogni accesso a un array, in fase di esecuzione si verificati
+Provando ad usare un indice non compreso nell'array, si ottiene un errore,
+perché per ogni accesso ad un array, in fase di esecuzione si verifica
 che l'indice sia compreso nei limiti. Accessi erronei di questo tipo
 causano molti bug in altri linguaggi di programmazione di sistema.
 
@@ -170,27 +170,27 @@ documentation][array].
 
 [array]: ../std/primitive.array.html
 
-# Le slice ("fette")
+# Slices ("Fette")
 
-Le ‘slice’ (pronunciato "slais") sono riferimenti a (o “viste" dentro)
-altre strutture dati.
-Servono a consentire un accesso sicuro ed efficiente a una porzione
+Le ‘slices’ (pronunciato "slaises") sono riferimenti a (o “viste" dentro)
+un'altra struttura dati.
+Servono a consentire un accesso sicuro ed efficiente ad una porzione
 di un array senza fare copie. Per esempio, si potrebbe voler far riferimento
-solamente a una riga di un file letto in memoria. Per sua natura, una slice
-non viene creata direttamente, ma partendo da una variabile esistente.
-Le slice hanno punto d'inizio e lunghezza costanti, ma il loro contenuto
+solamente ad una riga di un file letto in memoria. Per sua natura, una slice
+non viene creata direttamente, ma partendo da un legame di variabile esistente.
+Le slices hanno una lunghezza fissa, e il loro contenuto
 può essere mutabile o immutabile.
 
 Internamente, le slice sono rappresentate come un puntatore all'inizio
 dei dati e una lunghezza.
 
-## Sintassi delle slice
+## Sintassi delle slices
 
 Per creare una slice da vari oggetti si può usare la combinazione
 del carattere `&` e della coppia di caratteri `[]`. Il carattere `&` indica
-che le slice sono simili ai [riferimenti], che tratteremo in dettaglio
-più avanti in questa sezione. La coppia di caratteri `[]` che racchiude
-un range permette di definire la lunghezza della slice:
+che le slices sono simili ai [riferimenti], che tratteremo in dettaglio
+più avanti in questa sezione. La coppia di caratteri `[]`, utilizzata con un
+range, permette di definire la lunghezza della slice:
 
 ```rust
 let a = [0, 1, 2, 3, 4];
@@ -203,30 +203,31 @@ Le slice sono di tipo `&[T]`. Parleremo di quella `T` quando tratteremo la
 
 [genericità]: generics.html
 
-You can find more documentation for slices [in the standard library
-documentation][slice].
+Per maggiori informazioni sulle slices si consulti [la documentazione sulla
+libreria standard][slice].
 
 [slice]: ../std/primitive.slice.html
 
 # `str`
 
-Il tipo `str` di Rust è il tipo di stringa più primitivo. As an [unsized type][dst],
-it’s not very useful by itself, but becomes useful when placed behind a
-reference, like `&str`. We'll elaborate further when we cover
-[Strings][strings] and [references].
+Il tipo `str` di Rust è il tipo di stringa più primitivo.
+Come [tipo unsized][dst], non è molto utile di suo, ma diventa utile quando è
+utilizzato come riferimento, come per esempio `&str`. Tratteremo l'argomento
+in maniera più approfondita quando tratteremo le
+[Stringhe][strings] e i [riferimenti][references].
 
 [dst]: unsized-types.html
 [strings]: strings.html
 [references]: references-and-borrowing.html
 
-You can find more documentation for `str` [in the standard library
-documentation][str].
+Per maggiori informazioni sul tipo `str` si consulti [la documentazione sulla
+libreria standard][str].
 
 [str]: ../std/primitive.str.html
 
 # Ennuple
 
-Un'ennupla è una lista ordinata di lunghezza fissa. Come questa:
+Una ennupla è una lista ordinata di lunghezza fissa. Come questa:
 
 ```rust
 let x = (1, "ciao");
@@ -239,15 +240,17 @@ lo stesso codice, ma con il tipo annotato:
 let x: (i32, &str) = (1, "ciao");
 ```
 
-Come si vede, il tipo di un'ennupla somiglia all'ennupla, ma in ogni posizione
+Come si vede, il tipo di una ennupla somiglia all'ennupla, ma in ogni posizione
 c'è il tipo invece del valore. I lettori attenti noteranno anche che
 le ennuple sono eterogenee: in questa ennupla c'è un `i32` e un `&str`.
-Nei linguaggi di programmazione di sistema, strings are a bit more complex than in other
-languages. For now, read `&str` as a *string slice*, and we’ll learn more
-soon.
+Nei linguaggi di programmazione di sistema, le stringhe sono un pochino più
+complesse che negli altri linguaggi. Per adesso, si legga `&str` come *slice
+di stringa*, presto impareremo di più a riguardo.
 
-You can assign one ennupla into another, if they have the same contained types
-and [arity]. Le ennuple have the same arity when they have the same length.
+È possibile assegnare un bind su una ennupla ad un'altra ennupla,
+se entrambe le ennuple contengono gli
+stessi tipi di dato e hanno la stessa [arity]. Le tuple hanno la stessa arity
+quando hanno la stessa lunghezza.
 
 [arity]: glossary.html#arity
 
@@ -258,7 +261,7 @@ let y = (2, 3); // y: (i32, i32)
 x = y;
 ```
 
-Si può accedere ai campi di un'ennupla usando un *`let` destrutturante*.
+Si può accedere ai campi di una ennupla usando un *`let` destrutturante*.
 Ecco un esempio:
 
 ```rust
@@ -267,17 +270,18 @@ let (x, y, z) = (1, 2, 3);
 println!("x is {}", x);
 ```
 
-Remember [before][let] when I said the left-hand side of a `let` statement was more
-powerful than assigning a binding? Here we are. We can put a pattern on
-the left-hand side of the `let`, and if it matches up to the right-hand side,
-we can assign multiple bindings at once. In this case, `let` “destructures”
-or “breaks up” l'ennupla, and assigns the bits to three bindings.
+Ci ricordiamo di quando [prima][let] abbiamo detto che la parte sinistra di una
+istruzione `let` non era solo capace di fare un legame di variabile? Qui lo
+vediamo. Possiamo scrivere un pattern nella parte sinistra di una istruzione
+`let`, e se questo corrisponde alla parte destra, possiamo assegnare più
+legami di variabile alla volta. In questo caso, `let` "destruttura" or "rompe"
+l'ennupla, e assegna i suoi pezzi a tre legami.
 
 [let]: variable-bindings.html
 
-Questo pattern è molto potente, e lo ritroveremo ripetuto in seguito.
+Questo pattern è molto efficace, e lo ritroveremo ripetuto in seguito.
 
-Per disambiguare un'ennupla con un solo elemento da un valore
+Per discriminare una ennupla con un solo elemento da un valore
 tra parentesi, basta usare una virgola:
 
 ```rust
@@ -287,7 +291,7 @@ tra parentesi, basta usare una virgola:
 
 ## Indicizzazione delle ennuple
 
-I campi di un'ennupla possono esseree acceduti anche con la sintassi
+I campi di una ennupla possono essere acceduti anche con la sintassi
 di indicizzazione:
 
 
@@ -298,17 +302,17 @@ let x = ennupla.0;
 let y = ennupla.1;
 let z = ennupla.2;
 
-println!("x is {}", x);
+println!("x contiene {}", x);
 ```
 
-Come l'indicizzazione di array, parte da zero, ma diversamente
+L'indicizzazione, come per gli di array, parte da zero, ma diversamente
 dall'indicizzazione di array, usa un carattere `.`, invece della coppia
 di caratteri `[]`.
 
-You can find more documentation per le ennuple [in the standard library
-documentation][ennupla].
+Per maggiori informazioni sulle ennuple si consulti [la documentazione sulla
+libreria standard][tuple].
 
-[ennupla]: ../std/primitive.tuple.html
+[tuple]: ../std/primitive.tuple.html
 
 # Funzioni
 
@@ -320,5 +324,5 @@ fn foo(x: i32) -> i32 { x }
 let x: fn(i32) -> i32 = foo;
 ```
 
-In questo caso, `x` è un ‘puntatore a funzione’ che punta a una funzione
+In questo caso, `x` è un ‘puntatore a funzione’ che punta ad una funzione
 che prende un `i32` e rende un `i32`.

--- a/syntax-and-semantics.md
+++ b/syntax-and-semantics.md
@@ -1,10 +1,10 @@
-% Sintassi e semantica
+% Sintassi e Semantica
 
 Questo capitolo scompone Rust in pezzetti, uno per ogni concetto.
 
-Per chi preferisce imparare Rust dalle basi, un buon modo per farlo è
-leggere questi capitoli in sequenza.
+Per chi preferisce imparare Rust dalle basi in su, un buon modo per farlo è
+leggere questo capitolo in sequenza.
 
 Queste sezioni formano anche un riferimento per ogni concetto,
 così se leggendo un altro tutorial qualcosa non fosse chiaro, leggendo qui
-l'appropriato capitolo si può avere una spiegazione.
+l'appropriata sezione si può avere una spiegazione.

--- a/variable-bindings.md
+++ b/variable-bindings.md
@@ -2,7 +2,7 @@
 
 Praticamente qualunque programma in Rust più complesso di 'Hello World’ usa
 i *legami di variabile* ["variable binding"]. Tali istruzioni legano qualche
-valore a un nome, in modo da poter essere usato in seguito. Per introdurre
+valore ad un nome, in modo da poter essere usato in seguito. Per introdurre
 un legame, si usa la parola-chiave `let`, così:
 
 ```rust
@@ -13,9 +13,9 @@ fn main() {
 
 Mettere `fn main() {` in ogni esempio è un po' noioso, perciò in futuro
 lo ometteremo. Nel prosieguo, ci si ricordi di editare il corpo della propria
-funzion `main()`, invece di ometterla. Altrimenti, si otterrà un'errore.
+funzione `main()`, invece di ometterla. Altrimenti, si otterrà un'errore.
 
-# I pattern
+# I patterns
 
 In molti linguaggi, un legame di variabile verrebbe chiamato semplicemente
 *variabile*, ma i legami di variabile di Rust hanno alcuni assi nella manica.
@@ -26,8 +26,8 @@ non un semplice nome di variabile. Ciò significa che si può fare:
 let (x, y) = (1, 2);
 ```
 
-Dopo che questa istruzione viene eseguita, `x` varrà 1, e `y` varrà 2.
-I pattern sono veramente potenti, e hanno [una loro sezione][pattern]
+Dopo che questa istruzione viene eseguita, `x` varrà uno, e `y` varrà due.
+I pattern sono veramente vantaggiosi, e hanno [una loro sezione][pattern]
 in questo libro. Per adesso non ci servono quelle caratteristiche, e quindi
 le accantoneremo mentre proseguiamo.
 
@@ -38,10 +38,10 @@ le accantoneremo mentre proseguiamo.
 Rust è un linguaggio tipizzato staticamente, il che significa che specifichiamo
 subito i tipi, e questi vengono verificati in fase di compilazione. Allora
 perché il nostro primo esempio compilava? Beh, Rust ha una cosa chiamata
-‘inferenza dei tipi’. Se riesce a desumere qual'è il tipo di qualche oggetto,
+‘inferenza di tipo’. Se riesce a desumere qual'è il tipo di qualche dato,
 Rust non costringe a digitarlo esplicitamente.
 
-Però possiamo aggiungere il tipo, se vogliamo. I tipi si mettono dopo
+Se vogliamo, possiamo aggiungere il tipo di dato. I tipi si mettono dopo
 un punto-e-virgola (`:`):
 
 ```rust
@@ -53,10 +53,10 @@ di tipo `i32` al valore `cinque`.”
 
 In questo caso abbiamo scelto di rappresentare `x` come un intero con segno
 a 32 bit. Rust ha molti tipi interi primitivi. I loro nomi cominciano con `i`
-per gli interi con segno, e con `u` per gli interi senza segno. Le dimensioni
-intere possibili sono 8, 16, 32, e 64 bit.
+per gli interi con segno, e con `u` per gli interi senza segno (unsigned).
+Le dimensioni intere possibili sono 8, 16, 32, e 64 bit.
 
-Negli esempi futuri, possiamo annotare il tipo in un commento. Gli esempi si
+Negli esempi futuri, potremmo annotare il tipo in un commento. Gli esempi si
 presenteranno così:
 
 ```rust
@@ -106,7 +106,7 @@ ma non ne parleremo in questo libro. In generale, si può spesso evitare
 la mutazione esplicita, e quindi in Rust è preferibile evitarla. Detto questo,
 talvolta, la mutazione è quello che serve, e quindi non è proibita.
 
-# Inizializzare un legame
+# Inizializzare i legami
 
 I legami di variabile in Rust hanno un altro aspetto che differisce da altri
 linguaggi: i legami devono essere inizializzati con un valore prima di poterli
@@ -136,7 +136,7 @@ src/main.rs:2     let x: i32;
 
 Rust ci avverte che non abbiamo mai usato il legame di variabile, ma dato che
 non l'abbiamo mai usato, nessun danno, nessun fallo. Però le cose cambiano
-se proviamo a usare effettivamente questa `x`. Facciamolo. Modifichiamo
+se proviamo ad usare effettivamente questa `x`. Facciamolo. Modifichiamo
 il programma in modo che si presenti così:
 
 ```rust,ignore
@@ -165,12 +165,12 @@ Could not compile `hello_world`.
 
 Rust non ci permetterà di usare un valore che non è stato inizializzato.
 
-Prendiamo un minuto per parlare di questa roba che abbiamo aggiunto a
+Prendiamo un minuto per parlare di questa cosa che abbiamo aggiunto a
 `println!`.
 
 Se si inseriscono due graffe (`{}`, alcuni li chiamano baffi...) nella nostra
-stringa da stampare, Rust le interpreterà come una richiesta di intercalare
-al loro posto una sorta di valore. L'*interpolazione di stringhe* è un termine
+stringa da stampare, Rust le interpreterà come una richiesta di interpolare
+qualche sorta di valore. L'*interpolazione di stringa* è un termine
 informatico che significa "inserire una o più stringhe dentro un'altra stringa,
 al posto di altrettanti segnaposto." Dopo la nostra stringa, mettiamo
 una virgola, e una `x`, per indicare che vogliamo che `x` sia il valore che
@@ -185,7 +185,7 @@ molto complicati da stampare.
 
 [format]: ../std/fmt/index.html
 
-# Ambito e oscuramento
+# Ambito ed oscuramento
 
 Torniamo ai legami. I legami di variabile hanno un ambito - ossia sono
 vincolati a risiedere nel blocco in cui sono stati definiti. Un blocco è una
@@ -230,7 +230,7 @@ Could not compile `hello`.
 To learn more, run the command again with --verbose.
 ```
 
-Inoltre, i legami di variabile possono venire oscurati ["shadowed"]. Ciò
+Inoltre, i legami di variabile possono venire oscurati ("shadowed"). Ciò
 significa che un successivo legame di variabile con il medesimo nome di un
 legame attualmente nel suo ambito scavalcherà il legame precedente.
 
@@ -249,7 +249,7 @@ println!("{}", x); // Stampa "42"
 L'oscuramento e la mutabilità dei legami possono apparire come due facce
 della stessa medaglia, ma sono due concetti distinti che non sono sempre
 intercambiabili. Per dirne una, l'oscuramento ci consente di rilegare un nome
-a un valore di tipo diverso. È anche possibile cambiare la mutabilità
+ad un valore di tipo diverso. È anche possibile cambiare la mutabilità
 di un legame. Si noti che oscurare un nome non altera né distrugge il valore
 a cui era legato quel nome, e tale valore continuerà a esistere finché
 non esce di ambito, anche se non è più accessibile in nessun modo.


### PR DESCRIPTION
- Capitolo 4 parte I
  - Sintassi e Semantica
    - spell check
  - Legami di Variabile
    - spell check
  - Funzioni
    - _non si esce mai_ sostituito con _non rende nessun valore_
    - spell check
  - Tipi primitivi
    - rimosso link a while nella sezione `bool`
    - _slice_ sostituito con _slices_ nel caso sia un plurale
    - finita la traduzione della sezione Sintassi sulle slices
    - finita la traduzione della sezione `str`
    - finita la traduzione della sezione Ennuple
    - spell check
