### PR TITLE
Capitolo4 parte3

### DIFF
--- a/mutability.md
+++ b/mutability.md
@@ -33,7 +33,7 @@ let y = &mut x;
 
 [ref]: references-and-borrowing.html
 
-`y` è un legame immutabile a un riferimento mutabile, il che significa che non
+`y` è un legame immutabile ad un riferimento mutabile, il che significa che non
 si può legare 'y' a qualcos'altro (`y = &mut z`), ma `y` può essere usato
 per legare `x` a qualcos'altro (`*y = 5`). Una distinzione sottile.
 
@@ -44,7 +44,7 @@ let mut x = 5;
 let mut y = &mut x;
 ```
 
-Adesso `y` può essere legato a un altro valore, e inoltre il valore che sta
+Adesso `y` può essere legato ad un altro valore, ed inoltre il valore che sta
 referenziando può essere cambiato.
 
 È importante notare che `mut` fa parte di un [pattern][pattern], e perciò
@@ -81,7 +81,7 @@ il conteggio dei riferimenti. Però qui non abbiamo usato nessun `mut`, `x` è
 un legame immutabile, e non abbiamo preso il valore `&mut 5` né altri valori.
 E allora?
 
-Per capirlo, dobbiamo tornare al nucleo della filosofia guida di Rust, che è
+Per capirlo, dobbiamo tornare alla base della filosofia guida di Rust, che è
 la sicurezza di memoria, e al meccanismo col quale Rust la garantisce, che è
 il sistema di [possesso][possesso], e più specificamente,
 il [prestito][prestito]:
@@ -89,7 +89,7 @@ il [prestito][prestito]:
 > Si possono avere l'uno o l'altro di questi due tipi di prestiti, ma non
 > entrambi allo stesso tempo:
 >
-> * uno o più riferimenti immutabili (`&T`) a una risorsa,
+> * uno o più riferimenti (`&T`) ad una risorsa,
 > * esattamente un riferimento mutabile (`&mut T`).
 
 [ownership]: ownership.html
@@ -98,7 +98,7 @@ il [prestito][prestito]:
 Perciò, questa è la vera definizione di ‘immutabilità’: è sicuro che ci siano
 due puntatori a questo oggetto? Nel caso di `Arc<T>`, sì: la mutazione è
 contenuta interamente dentro la struttura stessa. Non si presenta all'utente.
-Per questa ragione, passa un `&T` a `clone()`. Se gli avesse passato
+Per questa ragione, `clone()` passa un `&T`. Se gli avesse passato
 un `&mut T`, però, sarebbe un errore.
 
 Altri tipi, come quelli nel modulo [`std::cell`][stdcell], sono

--- a/ownership.md
+++ b/ownership.md
@@ -12,8 +12,8 @@ in una sezione distinta:
   i ‘riferimenti’
 * i [tempi di vita][tempi di vita], un concetto avanzato di prestito
 
-Queste tre sezioni sono correlate, e seguono un ordine. Bisognerà leggerli
-tutti e tre per capire pienamente il sistema di possesso.
+Queste tre sezioni sono correlate, e seguono un ordine. Bisognerà leggerle
+tutte e tre per capire pienamente il sistema di possesso.
 
 [prestiti]: references-and-borrowing.html
 [tempi di vita]: lifetimes.html

--- a/ownership.md
+++ b/ownership.md
@@ -10,7 +10,7 @@ in una sezione distinta:
 * il possesso, che è la sezione attuale
 * i [prestiti][prestiti], e le caratteristiche a loro associate,
   i ‘riferimenti’
-* i [tempi di vita][tempi di vita], un avanzato concetto di prestito
+* i [tempi di vita][tempi di vita], un concetto avanzato di prestito
 
 Queste tre sezioni sono correlate, e seguono un ordine. Bisognerà leggerli
 tutti e tre per capire pienamente il sistema di possesso.
@@ -34,7 +34,7 @@ Però, questo sistema ha un certo costo: il tempo di apprendimento. Molti nuovi
 utenti di Rust sperimentano qualcosa che ci piace chiamare ‘combattere
 con il verificatore dei prestiti’, che è la parte del compilatore Rust che
 si rifiuta di compilare un programma che l'autore pensa essere valido. Ciò
-accade spesso perché il modello mentale del programmatore di come il possesso
+accade spesso perché il modello mentale del programmatore su come il possesso
 dovrebbe funzionare non combacia con le regole effettivamente implementate
 da Rust.
 Dapprima tutti sperimentano cose simili. Però, c'è una buona notizia:
@@ -42,7 +42,7 @@ gli sviluppatori Rust più esperti riferiscono che una volta che lavorano con
 le regole del sistema di possesso per un periodo di tempo, combattono sempre
 meno con il verificatore dei prestiti.
 
-Con questo in mente, vediamo in cosa consiste il possesso.
+Con questo in mente, vediamo di imparare riguardo al possesso.
 
 # Possesso
 
@@ -57,9 +57,9 @@ fn foo() {
 ```
 
 Quando `v` viene nell'ambito, viene creato un nuovo [vettore][vettori]
-sullo [stack][stack], e alloca spazio sullo [heap][heap] per i suoi elementi.
+sullo [stack][stack], ed allocato spazio sullo [heap][heap] per i suoi elementi.
 Quando `v` esce di ambito alla fine di `foo()`, Rust ripulirà ogni cosa
-correlata al vettore, anche la memoria allocata sullo heap. Questo avviene
+riguardo al vettore, anche la memoria allocata sullo heap. Questo avviene
 deterministicamente alla fine dell'ambito.
 
 Tratteremo i [vettori] in dettaglio più avanti in questo capitolo; li usiamo
@@ -81,8 +81,8 @@ in questo capitolo.
 # Semantica di spostamento
 
 Però qui c'è qualche altra sottigliezza: Rust assicura che ci sia _esattamente
-un_ legame a ogni data risorsa. Per esempio, se abbiamo un vettore, possiamo
-assegnarlo a un altro legame:
+un_ legame ad ogni data risorsa. Per esempio, se abbiamo un vettore, possiamo
+assegnarlo ad un altro legame:
 
 ```rust
 let v = vec![1, 2, 3];
@@ -120,7 +120,7 @@ println!("v[0] vale: {}", v[0]);
 ```
 
 Stesso errore: ‘use of moved value’. Quando si trasferisce il possesso
-di un oggetto da un legame a un altro, si dice che l'oggetto a cui si fa
+di un oggetto da un legame ad un altro, si dice che l'oggetto a cui si fa
 riferimento è stato ‘spostato’. Qui non ci vuole qualche sorta di annotazione
 speciale, è il normale comportamento di Rust.
 
@@ -136,15 +136,14 @@ let x = 10;
 ```
 
 Rust alloca sullo [stack][sh] della memoria per un intero [i32], copia i bit
-che rappresentano il valore 10 alla memoria allocata, e lega il nome
-della variabile x a questa regione di memoria per poterna riferire in seguito.
-
-[i32]: primitive-types.html#numeric-types
+che rappresentano il valore 10 nella memoria allocata, e lega il nome
+della variabile x a questa regione di memoria per poterne riferire in seguito.
 
 Adesso consideriamo il seguente frammento di codice:
 
 ```rust
 let v = vec![1, 2, 3];
+
 let mut v2 = v;
 ```
 
@@ -163,12 +162,12 @@ riguardo a cose come la lunghezza, la capacità, ecc.
 
 Quando si sposta `v` in `v2`, Rust effettivamente fa una copia bit-a-bit
 dell'oggetto vettore `v` nell'allocazione sullo stack rappresentata da `v2`.
-Questa copia superficiale non crea una copia dell'allocazione sullo heap
-contenente i dati effettivi.
+Questa copia superficiale ("shallow")
+non crea una copia dell'allocazione sullo heap contenente i dati effettivi.
 Il che significa che ci sarebbero due puntatori al contenuto del vettore
 entrambi che puntano alla stessa allocazione di memoria sullo heap.
 Se si potesse accedere sia a `v` che a `v2` nello stesso tempo, si violerebbe
-la garanzia di sicurezza di Rust, introducendo un'accesso concorrente ai dati.
+la garanzia di sicurezza di Rust, introducendo un accesso concorrente ai dati.
 
 Per esempio, se troncassimo il vettore ad appena due elementi tramite `v2`:
 
@@ -184,7 +183,7 @@ del vettore `v` sullo stack non concorda con la parte corrispondente sullo
 heap. `v` pensa ancora che ci siano tre elementi nel vettore e permetterebbe
 di accedere all'elemento non esistente `v[2]`, ma, come potremmo già sapere,
 questa è una ricetta per il disastro. Specialmente perché potrebbe condurre
-a un segmentation fault o peggio consentire a un utente non autorizzato
+ad un segmentation fault o peggio consentire a un utente non autorizzato
 di leggere da un'area di memoria a cui non dovrebbe aver accesso.
 
 Questa è la ragione per cui Rust proibisce di usare `v` dopo che l'abbiamo
@@ -192,21 +191,23 @@ spostato.
 
 [sh]: the-stack-and-the-heap.html
 
-È anche importante notare che le ottimizzazioni possono rimuovere la copia
-effettiva dei byte sullo stack, a seconda delle circostanza. Perciò potrebbe
-non essere così inefficiente come come sembra inizialmente.
+È anche importante notare che le ottimizzazioni potrebbero rimuovere la copia
+effettiva dei byte sullo stack, a seconda delle circostanze. Perciò
+potrebbe non essere così inefficiente come sembra inizialmente.
 
 ## I tipi `Copy`
 
 Abbiamo stabilito che quando il possesso viene trasferito a un altro legame,
 non si può più usare il legame originale. Però, c'è un [tratto][tratto] che
 cambia questo comportamento, e si chiama `Copy`. Non abbiamo ancora parlato
-dei tratti, ma per ora, si può pensare ad essi come annotazioni a tipi
-particolari che aggiungono ulteriori comportamenti. Per esempio:
+dei tratti, ma per ora, si può pensare ad essi come una annotazione di un
+tipo particolari che aggiunge un ulteriore comportamento. Per esempio:
 
 ```rust
 let v = 1;
+
 let v2 = v;
+
 println!("v vale: {}", v);
 ```
 
@@ -247,8 +248,8 @@ fn cambia_verita(x: bool) -> bool {
 ```
 
 Se avessimo usato dei tipi che non implementano il tratto `Copy`,
-avremmo ottenuto un errore di compilazione perché abbiamo provato a usare
-un valore spostato.
+avremmo ottenuto un errore di compilazione perché avremmo
+provato ad usare un valore spostato.
 
 ```text
 error: use of moved value: `a`
@@ -275,25 +276,26 @@ fn foo(v: Vec<i32>) -> Vec<i32> {
 }
 ```
 
-Ciò diventerebbe molto noioso. E peggiora più sono gli oggetti di cui vogliamo
-prendere possesso:
+Ciò diventerebbe molto noioso. E peggiora più sono gli oggetti
+di cui vogliamo prendere possesso:
 
 ```rust
 fn foo(v1: Vec<i32>, v2: Vec<i32>) -> (Vec<i32>, Vec<i32>, i32) {
     // fa' qualcosa con v1 e con v2
 
-    // restituisci il possesso di v1 e v2, e restituisci anche
-    // il risultato della nostra funzione
+    // restituisci il possesso di v1 e v2 
+    // e il risultato della nostra funzione
     (v1, v2, 42)
 }
 
 let v1 = vec![1, 2, 3];
 let v2 = vec![1, 2, 3];
+
 let (v1, v2, risposta) = foo(v1, v2);
 ```
 
-Mah! Il tipo reso, la riga finale della funzione, e la chiamata della funzione
-diventano parecchio più complicati.
+Mah! Il tipo reso, la riga finale della funzione, e la chiamata alla funzione
+diventano più complicati.
 
 Fortunatamente, Rust offre una caratteristica che aiuta a risolvere questo
 problema. Si chiama "prestito" ed è l'argomento della prossima sezione!

--- a/references-and-borrowing.md
+++ b/references-and-borrowing.md
@@ -12,8 +12,8 @@ in una sezione distinta:
 * i prestiti, che leggeremo adesso
 * [tempi di vita][tempi di vita], un concetto avanzato di prestito
 
-Queste tre sezioni sono correlate, e seguono un ordine. Bisognerà leggerli
-tutti e tre per capire pienamente il sistema di possesso.
+Queste tre sezioni sono correlate, e seguono un ordine. Bisognerà leggerle
+tutte e tre per capire pienamente il sistema di possesso.
 
 [possesso]: ownership.html
 [tempi di vita]: lifetimes.html

--- a/structs.md
+++ b/structs.md
@@ -2,7 +2,7 @@
 
 Le `struct` sono un modo di creare tipi di dati più complessi. Per esempio, se
 stessimo facendo calcoli che coinvolgono coordinate nello spazio 2D,
-cioè nel piano cartesiano ci servirebbero sia un valore `x` che un valore `y`:
+ci servirebbero sia un valore `x` che un valore `y`:
 
 ```rust
 let origine_x = 0;
@@ -10,7 +10,7 @@ let origine_y = 0;
 ```
 
 Una `struct` ci permette di combinare questi due oggetti in un singolo tipo
-di dati unificato, i cui campi sono etichettati `x` e `y`:
+di dato unificato, i cui campi sono etichettati `x` e `y`:
 
 ```rust
 struct Punto {
@@ -25,10 +25,11 @@ fn main() {
 }
 ```
 
-Qui ci sono molte cose, analizziamole. Una `struct` si dichiara con
-la parola-chiave `struct`, e poi con un nome. Per convenzione, le `struct`
-hanno la maiuscolizzazione del Pascal: `PuntoNelloSpazio`,
-non `Punto_Nello_Spazio`, né `punto_nello_spazio`.
+Qui ci sono molte cose, analizziamole a piccole dosi.
+Una `struct` si dichiara con
+la parola-chiave `struct`, e poi con un nome. Per convenzione, i nomi delle
+`struct`s iniziano con la lettera maiuscola e sono "camel cased": 
+`PuntoNelloSpazio`, non `Punto_Nello_Spazio`, né `punto_nello_spazio`.
 
 Possiamo creare un'istanza della nostra `struct` usando `let`, come al solito,
 ma per impostare ogni campo usiamo una sintassi con lo stile `chiave: valore`.
@@ -150,10 +151,10 @@ let punto = Punto3d { z: 1, x: 2, .. origine };
 
 # Strutture ennuple
 
-Rust ha un altro tipo di dati che è come un ibrido fra una [ennupla][ennupla]
+Rust ha un altro tipo di dato che è come un ibrido fra una [ennupla][ennupla]
 e una `struct`, e si chiama ‘struttura ennupla’. Le strutture ennuple hanno
 un nome, ma i loro campi no. Sono dichiarate con la parola-chiave `struct`,
-e poi con un nome seguito da un'ennupla:
+e poi con un nome seguito da una ennupla:
 
 [ennupla]: primitive-types.html#tuples
 
@@ -165,8 +166,8 @@ let nero = Colore(0, 0, 0);
 let origine = Punto(0, 0, 0);
 ```
 
-Qui, `nero` e `origine` non sono dello stesso tipo, anche se contengono campi
-degli stessi tipi.
+Qui, `nero` ed `origine` non sono uguali, anche se contengono gli
+stessi valori.
 
 Si può accedere ai membri di una struttura ennupla tramite la notazione a punto
 o il `let` destrutturante, proprio come le normali ennuple:
@@ -245,7 +246,8 @@ let x = Elettrone {};
 let y = Protone;
 ```
 
-Una tale `struct` è chiamata ‘simile a unità’ perché somiglia alla ennupla
+Una tale `struct` è chiamata ‘simile ad unità’ ("unit-like")
+perché somiglia alla ennupla
 vuota, `()`, che talvolta è chiamata ‘unità’. Come una struttura ennupla,
 definisce un nuovo tipo.
 
@@ -253,6 +255,6 @@ Questo tipo è usato raramente da solo (sebbene talvolta può servire come tipo
 marcatore), ma in combinazione con altre caratteristiche, può diventare utile.
 Per esempio, una libreria può chiedere di creare una struttura che implementi
 un certo [tratto][tratto] per gestire eventi. Se non si hanno dati da mettere
-nella struttura, si può creare `struct` simile a unità.
+nella struttura, si può creare `struct` simile ad unità.
 
 [tratto]: traits.html

--- a/vectors.md
+++ b/vectors.md
@@ -22,16 +22,16 @@ C'è una forma alternativa di `vec!` per ripetere un valore iniziale:
 let v = vec![0; 10]; // dieci zeri
 ```
 
-I vettori immagazzinano il loro contenuto sullo heap come array contigui
+I vettori immagazzinano il loro contenuto nella memoria heap come array contigui
 di `T`. Ciò significa che devono essere capaci di sapere la dimensione di `T`
 in fase di compilazione (cioè, quanti byte servono per memorizzare un `T`?).
 La dimensione di alcuni oggetti non si può sapere in fase di compilazione.
 Per tali oggetti si dovrà immagazzinare un puntatore a quell'oggetto:
-fortunatamente, il tipo [`Box`][box] funziona perfettamente a questo scopo.
+fortunatamente, il tipo [`Box`][box] funziona perfettamente per questo scopo.
 
 ## Accedere agli elementi
 
-Per ottenere il valore a un particolare indice nel vettore, si usano le `[]`:
+Per ottenere il valore ad un particolare indice nel vettore, si usano le `[]`:
 
 ```rust
 let v = vec![1, 2, 3, 4, 5];
@@ -67,12 +67,12 @@ note: the type `collections::vec::Vec<_>` cannot be indexed by `i32`
 error: aborting due to previous error
 ```
 
-C'è molta punteggiatura in quel messaggio, ma il suo nucleo significa:
-non si può indicizzare con un `i32`.
+C'è molta punteggiatura in quel messaggio, ma il suo significato
+è il seguente: non si può indicizzare con un `i32`.
 
 ## Accesso fuori dai limiti
 
-Se si prova ad accedere un indice che non esiste:
+Se si prova l'accesso ad un indice che non esiste:
 
 ```rust,ignore
 let v = vec![1, 2, 3];
@@ -85,7 +85,7 @@ allora il thread attuale andrà in [panico] con un messaggio come questo:
 thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 7'
 ```
 
-Se si vuole gestire gli errori di accesso fuori dai limiti senza andare
+Se si vogliono gestire gli errori di accesso fuori dai limiti senza andare
 in panico, si possono usare metodi come [`get`][get] o [`get_mut`][get_mut],
 che restituiscono `None` quando gli viene dato un indice invalido:
 
@@ -118,7 +118,7 @@ for i in v {
 }
 ```
 
-Nota: Non si può usare ancora il vettore dopo averlo iterato prendendone
+Nota: Non si può riusare il vettore dopo averlo iterato prendendone
 il possesso. Invece, si può iterare il vettore più volte se quando lo si itera
 se ne prende un riferimento.
 Per esempio, il seguente codice non compila.


### PR DESCRIPTION
- Capitolo 4 parte III
  - Vectors
    - spell check
  - Ownership
    - rimosso il riferimento a [i32] nella sezione Dettagli
    - spell check
  - References and borrowing
    - spell check
    - Tradotta la sezione Meta
    - Finita di tradurre la prima parte
    - _issues_ tradotto con _problemi_
  - Lifetimes
    - Tradotta la sezione Meta
    - spell check
  - Mutability
    - spell check
  - Structs
    - spell check
